### PR TITLE
Docker Container with DockerHub Automated Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.git/**
+.github/
+.github/**
+*.yml
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM alpine:3.3
+MAINTAINER jp@roemer.im
+
+# Install Gosu to /usr/local/bin/gosu
+ADD https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64 /usr/local/sbin/gosu
+
+# Install runtime dependencies & create runtime user
+RUN chmod +x /usr/local/sbin/gosu \
+ && echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" | tee -a /etc/apk/repositories \
+ && apk --no-cache --no-progress add ca-certificates git libgit2@testing \
+ && adduser -D app -h /data -s /bin/sh
+
+# Copy source code to the container & build it
+COPY . /app
+WORKDIR /app
+RUN ./docker/build.sh
+
+# NSSwitch configuration file
+COPY docker/nsswitch.conf /etc/nsswitch.conf
+
+# App configuration
+ENV G2E_REPO_PATH "/data/repo"
+
+# Container configuration
+VOLUME ["/data"]
+EXPOSE 4242
+CMD ["/usr/local/sbin/gosu", "app", "/app/git2etcd"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -x
+set -e
+
+# Set temp environment vars
+export GOPATH=/tmp/go
+export PATH=${PATH}:${GOPATH}/bin
+export BUILDPATH=${GOPATH}/src/github.com/blippar/git2etcd
+
+# Install build deps
+apk --no-cache --no-progress add go gcc musl-dev libgit2-dev@testing
+
+# Init go environment to build git2etcd
+mkdir -p $(dirname ${BUILDPATH})
+ln -s /app ${BUILDPATH}
+cd ${BUILDPATH}
+go get -v
+go build
+
+# Cleanup GOPATH
+rm -r ${GOPATH}
+
+# Remove build deps
+apk --no-cache --no-progress del go gcc musl-dev libgit2-dev

--- a/docker/nsswitch.conf
+++ b/docker/nsswitch.conf
@@ -1,0 +1,17 @@
+
+# /etc/nsswitch.conf
+
+passwd:         compat
+group:          compat
+shadow:         compat
+
+hosts:          files dns
+networks:       files
+
+protocols:      db files
+services:       db files
+ethers:         db files
+rpc:            db files
+
+netgroup:       nis
+


### PR DESCRIPTION
- Resolves #4 
- Add `Dockerfile` & assets (in `docker/`) for container building
- Automated build has been set on https://hub.docker.com/r/blippar/git2etcd
- `G2E_REPO_PATH` has been set to `/data/repo` as default, this allow the use of a volume for `/data`
- `/data` is also the home of the runtime user `app`, this way monting your deploy key in this folder with `chown 500:500 *key*` makes it availlable for the user.
