### PR TITLE
Build, Webhook & JSON config fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,8 +1,9 @@
 build:
   image: golang:$$GO_VERSION
   commands:
-   - echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" | tee -a /etc/apk/repositories
-   - apk --no-cache --quiet add libgit2-dev@testing curl git cvs gcc musl-dev
+   - apk --no-cache --quiet add curl git cvs gcc musl-dev make cmake libssh2-dev openssl-dev
+   - ./docker/install-libgit2.sh
+   - export PKG_CONFIG_PATH="/usr/lib/pkgconfig/:/usr/local/lib/pkgconfig/"
    - go get
    - go build
    - go test

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,4 +12,3 @@ matrix:
   GO_VERSION:
     - 1.6-alpine
     - 1.5-alpine
-    - 1.4-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ ADD https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64 /usr/local/s
 
 # Install runtime dependencies & create runtime user
 RUN chmod +x /usr/local/sbin/gosu \
- && echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" | tee -a /etc/apk/repositories \
- && apk --no-cache --no-progress add ca-certificates git libgit2@testing \
+ && apk --no-cache --no-progress add ca-certificates git libssh2 openssl \
  && adduser -D app -h /data -s /bin/sh
 
 # Copy source code to the container & build it

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Key | Description | Default
 `host.port` | Port to listen to | `"4242"`
 `host.hook` | Name of the Webhook endpoint | `"hook"`
 `repo.url` | URL of the repo to sync | `"https://github.com/0rax/fishline.git"`
+`repo.branch` | Branch of the repo to sync | `"master"`
 `repo.path` | Path where to clone the repo | `"/opt/git2etcd/repo"`
 `repo.synccycle` | Number of seconds between 2 automatic syncs (if 0, never syncs) | `3600`
 `etcd.hosts` | List of etcd hosts | `["http://127.0.0.1:2379"]`
@@ -44,6 +45,7 @@ You can use a JSON config file that you would put either in current folder or in
   },
   "repo": {
     "url": "https://github.com/0rax/fishline.git",
+    "branch": "master",
     "path": "/opt/git2etcd/repo"
   },
   "etcd": {

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -6,9 +6,13 @@ set -e
 export GOPATH=/tmp/go
 export PATH=${PATH}:${GOPATH}/bin
 export BUILDPATH=${GOPATH}/src/github.com/blippar/git2etcd
+export PKG_CONFIG_PATH="/usr/lib/pkgconfig/:/usr/local/lib/pkgconfig/"
 
 # Install build deps
-apk --no-cache --no-progress add go gcc musl-dev libgit2-dev@testing
+apk --no-cache --no-progress --virtual build-deps add go gcc musl-dev make cmake openssl-dev libssh2-dev
+
+# Install libgit2
+./docker/install-libgit2.sh
 
 # Init go environment to build git2etcd
 mkdir -p $(dirname ${BUILDPATH})
@@ -21,4 +25,4 @@ go build
 rm -r ${GOPATH}
 
 # Remove build deps
-apk --no-cache --no-progress del go gcc musl-dev libgit2-dev
+apk --no-cache --no-progress del build-deps

--- a/docker/install-libgit2.sh
+++ b/docker/install-libgit2.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -x
+set -e
+
+# Set temp environment vars
+export LIBGIT2REPO=https://github.com/libgit2/libgit2.git
+export LIBGIT2BRANCH=v0.23.4
+export LIBGIT2PATH=/tmp/libgit2
+
+# Compile & Install libgit2 (v0.23)
+git clone -b ${LIBGIT2BRANCH} --depth 1 -- ${LIBGIT2REPO} ${LIBGIT2PATH}
+
+mkdir -p ${LIBGIT2PATH}/build
+cd ${LIBGIT2PATH}/build
+cmake .. -DBUILD_CLAR=off
+cmake --build . --target install
+
+# Cleanup
+rm -r ${LIBGIT2PATH}

--- a/git.go
+++ b/git.go
@@ -25,7 +25,9 @@ func openOrCloneRepo() error {
 			viper.Set("repo.branch", "master")
 		}
 		cloneOptions.CheckoutBranch = viper.GetString("repo.branch")
-		log.Info("Cloning repo: ", viper.GetString("repo.path"), " on branch ", viper.GetString("repo.branch"))
+		log.Info("Cloning repo ", viper.GetString("repo.url"),
+			" on branch ", viper.GetString("repo.branch"),
+			" (in ", viper.GetString("repo.path"), ")")
 		gitRepo, err = git.Clone(viper.GetString("repo.url"), viper.GetString("repo.path"), cloneOptions)
 		if err != nil {
 			return err

--- a/git.go
+++ b/git.go
@@ -20,9 +20,12 @@ func openOrCloneRepo() error {
 				CertificateCheckCallback: certificateCheckCallback,
 			},
 		}
-		if viper.IsSet("repo.branch") {
-			cloneOptions.CheckoutBranch = viper.GetString("repo.branch")
+		if viper.GetString("repo.branch") == "" {
+			// Default value is not correctly assigned to repo.branch when using json config, forcing it here
+			viper.Set("repo.branch", "master")
 		}
+		cloneOptions.CheckoutBranch = viper.GetString("repo.branch")
+		log.Info("Cloning repo: ", viper.GetString("repo.path"), " on branch ", viper.GetString("repo.branch"))
 		gitRepo, err = git.Clone(viper.GetString("repo.url"), viper.GetString("repo.path"), cloneOptions)
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -159,7 +158,7 @@ func treatPushEvent(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	fmt.Println(*event.After)
+	log.Info("Repository head is now ", *event.After)
 	oid, _ := git.NewOid(*event.After)
 	commit, err := gitRepo.LookupCommit(oid)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -159,8 +159,8 @@ func treatPushEvent(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	fmt.Println(*event.Head)
-	oid, _ := git.NewOid(*event.Head)
+	fmt.Println(*event.After)
+	oid, _ := git.NewOid(*event.After)
 	commit, err := gitRepo.LookupCommit(oid)
 	if err != nil {
 		log.WithError(err).Error("Couldn't get HEAD's commit")


### PR DESCRIPTION
This PR contains a lot of small fixes concerning the container build, the webhook endpoint and a bug when using json config files
##### Container build
- Alpine Linux does not have a libgit2 availlable on 3.3 repository so we had to cherry pick it from the testing repository previously
- Due to this the build was broken as the libgit2 has been updated to v0.24 on Alpine testing repository
- Tried to up version of git2go to 0.24 to match libgit2 version but the application was not able to boot up
- Decided to build the libgit2 as part of the testing / container building process in order to make it a pinned dependencies alongside git2go.v23
- Also removed testing with go1.4 as github.com/coreos/etcd/client no longer compiles on it
##### Webhook panic
- Found a panic when recieving an incoming webhook, this was due to a change / missinformation in GitHub documentation
- Its stated that the HEAD pointer was located in the `head` section of the JSON while in reality it was located in the `after` section of the payload
- We now use the correct pointer to `after` and not `head`
- Changed a fmt.Println to a log.Info in the same section
##### JSON configuration
- When parsing a JSON config file viper does not set the default value for `repo.branch` correctly.
- It sets it to `""` instead making further access to this variable not reliable
- Forced this value to be set to master when set to `""` when initializing the repository
- Added some log to show remote origin & branch before cloning
- Also added `repo.branch` to the documetation as it was omited and was the cause of the bug
- This may cause other problem with default and should be investigated
- Resolves #9 
